### PR TITLE
chore: change CODEOWNERS to a GH team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # is the same as .gitignore.
 
 # The owners for all files in the repo.
-* @devjgm @coryan
+* @google/oss-policies-owners


### PR DESCRIPTION
The owners of this repo will be those in the
https://github.com/orgs/google/teams/oss-policies-owners/ GH
team.