### PR TITLE
doc: update C++ matrix circa 2023-02

### DIFF
--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -1,36 +1,37 @@
 # Foundational C++ Support
 
-| Dimension       | Supported Version     | Last Changed |
-|-----------------|-----------------------|--------------|
-| C++ Version     | >= 14                 | 2022-07-01   |
-| CMake           | >= 3.10               | 2022-07-01   |
-| Bazel           | >= 4.0                | 2022-07-01   |
-| GCC             | >= 7.3.1              | 2022-07-01   |
-| Clang           | >= 6.0.0              | 2022-07-01   |
-| MSVC            | >= 2017               | 2022-07-01   |
-| Apple Clang     | >= 12                 | 2022-07-01   |
-| Android NDK API | == 19                 | 2022-07-01   |
-| Alpine          | >= 3.14               | 2022-07-01   |
-| Debian          | >= 10                 | 2022-07-01   |
-| Fedora          | >= 35                 | 2022-07-01   |
-| openSUSE        | >= Leap 15.3          | 2022-07-01   |
-| Ubuntu LTS      | >= 18.04              | 2022-07-01   |
-| RHEL            | >= 7 ([*1])           | 2022-07-01   |
-| CentOS          | 7 ([*1])              | 2022-07-01   |
-| RockyLinux      | 8                     | 2022-07-01   |
-| Windows Server  | >= 2016               | 2022-07-01   |
-| Windows Client  | >= 10                 | 2022-07-01   |
-| macOS           | >= 10.11 (El Capitan) | 2022-07-01   |
-| iOS             | >= 12.0               | 2022-07-01   |
+| Dimension       | Supported Version     | Last Changed | Next Change [^next-change] |
+|-----------------|-----------------------|--------------|-------------|
+| C++ Version     | >= 14                 | 2022-07-01   | 2024-12-15  |
+| CMake           | >= 3.10               | 2022-07-01   | 2023-05-01  |
+| Bazel           | >= 4.0                | 2022-07-01   | 2023-04-01  |
+| GCC             | >= 7.3.1              | 2022-07-01   | 2024-07-01  |
+| Clang           | >= 6.0.0              | 2022-07-01   | 2023-05-01  |
+| MSVC            | >= 2017               | 2022-07-01   | 2023-07-01  |
+| Apple Clang     | >= 12                 | 2022-07-01   | |
+| Android NDK API | == 19                 | 2022-07-01   | |
+| Alpine          | >= 3.14               | 2022-07-01   | 2023-06-01 |
+| Debian          | >= 10                 | 2022-07-01   | 2024-07-01 |
+| Fedora          | >= 36                 | 2022-02-24   | 2023-06-01 |
+| openSUSE        | >= Leap 15.4          | 2023-02-24   | 2024-01-01 |
+| Ubuntu LTS      | >= 18.04              | 2022-07-01   | 2023-05-01 |
+| RHEL            | >= 7 [^rhel-7]        | 2022-07-01   | 2024-07-01 |
+| CentOS          | 7 [^rhel-7]           | 2022-07-01   | 2024-07-01 |
+| RockyLinux      | 8                     | 2022-07-01   | 2024-06-01 |
+| Windows Server  | >= 2019               | 2022-02-24   | 2024-02-01 |
+| Windows Client  | >= 10                 | 2022-07-01   | 2025-11-01 |
+| macOS           | >= 11 (Big Sur)       | 2022-02-24   | 2026-12-01 |
+| iOS             | >= 12.0               | 2022-07-01   | |
 
-### Footnotes
+[^next-change]: This is an estimated date. The actual date may change if the
+vendor (or community, as applicable) extends or shortens the lifetime of the
+dimension in question.
+
+[^rhel-7]: We require the [devtoolset-7] toolchain (compiler, linker, build
+tools, etc.) on RHEL 7 and CentOS 7.
+
+### Notes
 
 The relevant policies are described at https://opensource.google/documentation/policies/cplusplus-support.
 
-#### RHEL 7
-
-We require the [devtoolset-7] toolchain (compiler, linker, build tools, etc.) on
-RHEL 7 and CentOS 7.
-
 [devtoolset-7]: https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/
-[*1]: #rhel-7


### PR DESCRIPTION
We can update the minimum requirements for Fedora and openSUSE.  I am pretty sure we can update Windows Server to 2019, as 2016 went out of mainline support.  I am less certain about macOS.

I added a new column with the expected date for the next change, the date is estimated, usually the first day of the month *following* the EOL date.  I could use some help filling out the dates for some rows there.

And made some footnotes into real footnotes (the rendered versions in  [my branch](https://github.com/coryan/oss-policies-info/blob/doc-update-cxx-matrix-2023-02/foundational-cxx-support-matrix.md) may help).
