### PR TITLE
chore: updates around 2023-06-01

### DIFF
--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -38,7 +38,7 @@ version.
 that ships with one of the supported distros.
 
 [^clang]: We support the oldest version of Clang that ships with one of the
-supported distros. Currently that is CLang 7.0 as Ubuntu 20.04 ships with
+supported distros. Currently that is Clang 7.0 as Ubuntu 20.04 ships with
 this version.
 
 ### Notes


### PR DESCRIPTION
Ubuntu 18.04 reached EOL, that bumps the minimum version for Ubuntu, CMake and Clang.

Add some footnotes to make it easier to follow the expected dates.