### PR TITLE
Update Ruby support matrix to drop Ruby 2.7

### DIFF
--- a/foundational-ruby-support-matrix.md
+++ b/foundational-ruby-support-matrix.md
@@ -3,7 +3,7 @@
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
-| Ruby Version    | >= 2.7            | 2023-06-07   | 2024-03-01                 |
+| Ruby Version    | >= 3.0            | 2024-04-29   | 2025-04-23                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the


### PR DESCRIPTION
Ruby 2.7 was EOL on 3/31/2023 (>1 year ago), and has thus reached end-of-support per the [Ruby support policy](https://cloud.google.com/ruby/getting-started/supported-ruby-versions)