### PR TITLE
Update foundational-java-support-matrix.md

### DIFF
--- a/foundational-java-support-matrix.md
+++ b/foundational-java-support-matrix.md
@@ -4,7 +4,7 @@
 | Dimension         | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------------|-------------------|--------------|----------------------------|
 | Java Version      | >= 8              | 2024-01-30   | 2026-11-12                 |
-| Android API Level | >= 21             | 2024-01-30   | 2024-07-24                 |
+| Android API Level | >= 21             | 2024-01-30   | 2025-07-24                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the


### PR DESCRIPTION
Extend next change date for Android API Level since the Jetpack default is still 21: https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/docs/api_guidelines/modules.md#module-minsdkversion