### PR TITLE
Update foundational-php-support-matrix.md

### DIFF
--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -3,7 +3,7 @@
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|
 | PHP Version | >= 8.1            | 2024-12-17   | 2025-12-31                 |
-| Composer    | >= 2.8            | 2024-10-07   | 2025-01-01                 |
+| Composer    | >= 2.8            | 2024-10-07   | 2025-04-02                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the


### PR DESCRIPTION
Extend composer "Next change" date

v2.8 is still the latest release. There doesn't seem to be a predictable release date for v2.9, but check back in ~April based on historic release frequency: https://endoflife.date/composer