### PR TITLE
update foundational-php-support-matrix

### DIFF
--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -3,7 +3,7 @@
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|
 | PHP Version | >= 8.1            | 2024-12-17   | 2025-12-31                 |
-| Composer    | >= 2.8            | 2024-10-07   | 2025-04-02                 |
+| Composer    | >= 2.8            | 2024-10-07   | 2025-07-02                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the


### PR DESCRIPTION
https://endoflife.date/composer still does not have an EOL date, bumped 3 months to July to check again.