### PR TITLE
Reorganize foundational-cxx page into multiple tables.

### DIFF
--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -30,7 +30,7 @@ This document captures the specific version numbers as resolved by those policie
 ## Android NDK
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
-| Android API (target)   | == 21                  | 2022-09-18   |  |
+| Android API (target)   | >= 21                  | 2022-09-18   |  |
 
 ## Compilers, tools, build systems
 

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -22,14 +22,14 @@ This document captures the specific version numbers as resolved by those policie
 
 ## macOS
 | Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
-|-----------------|------------------------|--------------|-------------|
+|-------------------|------------------------|--------------|-------------|
 | Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
 | macOS (target)    | >= 11 (Big Sur)        | 2024-09-17   | 2025-07-30 |
 | iOS  (target)     | >= 15                  | 2024-01-24   | 2025-07-30 |
 
 ## Android NDK
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
-|-----------------|------------------------|--------------|-------------|
+|------------------------|------------------------|--------------|----------------------------|
 | Android API (target)   | >= 21                  | 2022-09-18   |  |
 
 ## Compilers, tools, build systems

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -1,5 +1,35 @@
 # Foundational C++ Support
 
+The relevant policies are described at https://opensource.google/documentation/policies/cplusplus-support.
+This document captures the specific version numbers as resolved by those policies.
+
+## Linux distributions
+| Distribution    | Supported Version      | Last Changed | Next Change [^next-change] |
+| Alpine          | >= 3.19                | 2025-06-04   | 2025-11-01 |
+| Debian          | >= 11                  | 2024-07-01   | 2026-06-30 |
+| Fedora          | >= 41                  | 2025-06-04   | 2025-12-01 |
+| openSUSE        | >= Leap 15.6           | 2024-12-31   | 2025-12-31 |
+| Ubuntu LTS      | >= 22.04               | 2025-06-04   | 2027-05-01 |
+| RHEL            | >= 9                   | 2024-07-01   | 2027-06-01 |
+| RockyLinux      | >= 9                   | 2024-07-01   | 2027-06-01 |
+
+## Windows
+| Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
+| Windows Server  | >= 2022                | 2024-01-22   | 2026-10-13 |
+| Windows Client  | >= 10                  | 2022-07-01   | 2025-11-01 |
+
+## macOS
+| Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
+| Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
+| macOS (target)    | >= 11 (Big Sur)        | 2024-09-17   | 2025-07-30 |
+| iOS  (target)     | >= 15                  | 2024-01-24   | 2025-07-30 |
+
+## Android NDK
+| Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
+| Android API (target)   | == 21                  | 2022-09-18   |  |
+
+## Compilers, tools, build systems
+
 | Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | C++ Version     | >= 17                  | 2024-12-17   | 2027-12-15  |
@@ -9,18 +39,6 @@
 | Clang           | >= 14.0.0              | 2025-06-04   | 2027-05-01 [^clang] |
 | MSVC            | >= 2022                | 2024-04-29   | 2027-01-12  |
 | Apple Clang     | >= 12                  | 2022-07-01   | 2025-07-30 |
-| Android NDK API | == 21                  | 2022-09-18   | |
-| Alpine          | >= 3.19                | 2025-06-04   | 2025-11-01 |
-| Debian          | >= 11                  | 2024-07-01   | 2026-06-30 |
-| Fedora          | >= 41                  | 2025-06-04   | 2025-12-01 |
-| openSUSE        | >= Leap 15.6           | 2024-12-31   | 2025-12-31 |
-| Ubuntu LTS      | >= 22.04               | 2025-06-04   | 2027-05-01 |
-| RHEL            | >= 9                   | 2024-07-01   | 2027-06-01 |
-| RockyLinux      | >= 9                   | 2024-07-01   | 2027-06-01 |
-| Windows Server  | >= 2022                | 2024-01-22   | 2026-10-13 |
-| Windows Client  | >= 10                  | 2022-07-01   | 2025-11-01 |
-| macOS           | >= 11 (Big Sur)        | 2024-09-17   | 2025-07-30 |
-| iOS             | >= 15                  | 2024-01-24   | 2025-07-30 |
 | glibc           | >= 2.27                | 2024-07-09   | TBD [^glibc] |
 | musl            | >= 1.2.4               | 2024-12-17   | 2025-05-09 |
 
@@ -43,6 +61,5 @@ this version.
 
 ### Notes
 
-The relevant policies are described at https://opensource.google/documentation/policies/cplusplus-support.
 
 [devtoolset-7]: https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -5,6 +5,7 @@ This document captures the specific version numbers as resolved by those policie
 
 ## Linux distributions
 | Distribution    | Supported Version      | Last Changed | Next Change [^next-change] |
+|-----------------|------------------------|--------------|-------------|
 | Alpine          | >= 3.19                | 2025-06-04   | 2025-11-01 |
 | Debian          | >= 11                  | 2024-07-01   | 2026-06-30 |
 | Fedora          | >= 41                  | 2025-06-04   | 2025-12-01 |
@@ -15,17 +16,20 @@ This document captures the specific version numbers as resolved by those policie
 
 ## Windows
 | Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
+|-----------------|------------------------|--------------|-------------|
 | Windows Server  | >= 2022                | 2024-01-22   | 2026-10-13 |
 | Windows Client  | >= 10                  | 2022-07-01   | 2025-11-01 |
 
 ## macOS
 | Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
+|-----------------|------------------------|--------------|-------------|
 | Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
 | macOS (target)    | >= 11 (Big Sur)        | 2024-09-17   | 2025-07-30 |
 | iOS  (target)     | >= 15                  | 2024-01-24   | 2025-07-30 |
 
 ## Android NDK
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
+|-----------------|------------------------|--------------|-------------|
 | Android API (target)   | == 21                  | 2022-09-18   |  |
 
 ## Compilers, tools, build systems

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -30,7 +30,7 @@ This document captures the specific version numbers as resolved by those policie
 ## Android NDK
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
 |------------------------|------------------------|--------------|----------------------------|
-| Android API (target)   | >= 21                  | 2022-09-18   |  |
+| Android API (target)   | >= 21                  | 2022-09-18   |                            |
 
 ## Compilers, tools, build systems
 

--- a/foundational-dotnet-support-matrix.md
+++ b/foundational-dotnet-support-matrix.md
@@ -54,7 +54,3 @@ choose to target .NET Standard, typically .NET Standard 2.0
 Standard](https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/)
 so there are no dates for when .NET Standard support will be removed
 or updated.
-
-### Footnotes
-
-The relevant policies are described at https://opensource.google/documentation/policies/dotnet-support

--- a/foundational-java-support-matrix.md
+++ b/foundational-java-support-matrix.md
@@ -1,6 +1,8 @@
 
 # Foundational Java Support
 
+The relevant policies are described at https://opensource.google/documentation/policies/cplusplus-support. This document captures the specific version numbers as resolved by those policies.
+
 | Dimension         | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------------|-------------------|--------------|----------------------------|
 | Java Version      | >= 8              | 2024-01-30   | 2026-11-12                 |
@@ -11,8 +13,6 @@ vendor (or community, as applicable) extends or shortens the lifetime of the
 dimension in question.
 
 ### Footnotes
-
-The relevant policies are described at https://cloud.google.com/java/docs/supported-java-versions.
 
 On Android, we support the minimum SDK version that is supported by
 [Google Play services](https://developers.google.com/android/guides/setup) and

--- a/foundational-java-support-matrix.md
+++ b/foundational-java-support-matrix.md
@@ -1,7 +1,7 @@
 
 # Foundational Java Support
 
-The relevant policies are described at https://opensource.google/documentation/policies/cplusplus-support. This document captures the specific version numbers as resolved by those policies.
+The relevant policies are described at https://cloud.google.com/java/docs/supported-java-versions. This document captures the specific version numbers as resolved by those policies.
 
 | Dimension         | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------------|-------------------|--------------|----------------------------|

--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -1,5 +1,7 @@
 # Foundational PHP Support
 
+The relevant policies are described at https://cloud.google.com/php/getting-started/supported-php-versions. This document captures the specific version numbers as resolved by those policies.
+
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|
 | PHP Version | >= 8.1            | 2024-12-17   | 2025-12-31                 |
@@ -9,6 +11,3 @@
 vendor (or community, as applicable) extends or shortens the lifetime of the
 dimension in question.
 
-### Footnotes
-
-The relevant policies are described at https://cloud.google.com/php/getting-started/supported-php-versions.

--- a/foundational-python-support-matrix.md
+++ b/foundational-python-support-matrix.md
@@ -1,6 +1,8 @@
 
 # Foundational Python Support
 
+The relevant policies are described at https://opensource.google/documentation/policies/supported-python-versions. This document captures the specific version numbers as resolved by those policies.
+
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
 | Python Version  | >= 3.9            | 2024-11-18   | 2025-10-31                 |
@@ -8,7 +10,3 @@
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the
 dimension in question.
-
-### Footnotes
-
-The relevant policies are described at https://cloud.google.com/python/docs/supported-python-versions

--- a/foundational-ruby-support-matrix.md
+++ b/foundational-ruby-support-matrix.md
@@ -1,6 +1,8 @@
 
 # Foundational Ruby Support
 
+The relevant policies are described at https://cloud.google.com/ruby/getting-started/supported-ruby-versions. This document captures the specific version numbers as resolved by those policies.
+
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
 | Ruby Version    | >= 3.1            | 2025-06-02   | 2025-09-15                 |
@@ -9,6 +11,3 @@
 vendor (or community, as applicable) extends or shortens the lifetime of the
 dimension in question.
 
-### Footnotes
-
-The relevant policies are described at https://cloud.google.com/ruby/getting-started/supported-ruby-versions.


### PR DESCRIPTION
This is a first pass to clarify this with no intended change to policy.

Besides reformatting this affects:

- Link to the corresponding long-form policy page at the top of each page, declaring that policy to be authoritative and this repo only capturing the current concrete numbers as reconciled from those policies.
- Document the supported XCode version (per policy latest XCode is supported)
- Add `(target)` to a few rows which were about targeting instead of building on (for example, the policy didn't intend to support compiling on iOS)
- Adjust android API level to be >= instead of ==, since that seemed to be the intended semantic already (I think arguably it means we would compile things with minsdk set equal to that value, but it >= seems to be the clearer implication).