### PR TITLE
Update oss support matrix for 2025Q4

### DIFF
--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -6,9 +6,9 @@ This document captures the specific version numbers as resolved by those policie
 ## Linux distributions
 | Distribution    | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
-| Alpine          | >= 3.19                | 2025-06-04   | 2025-11-01 |
+| Alpine          | >= 3.20                | 2025-12-16   | 2026-04-01 |
 | Debian          | >= 11                  | 2024-07-01   | 2026-06-30 |
-| Fedora          | >= 41                  | 2025-06-04   | 2025-12-01 |
+| Fedora          | >= 42                  | 2025-12-16   | 2026-05-13 |
 | openSUSE        | >= Leap 15.6           | 2024-12-31   | 2025-12-31 |
 | Ubuntu LTS      | >= 22.04               | 2025-06-04   | 2027-05-01 |
 | RHEL            | >= 9                   | 2024-07-01   | 2027-06-01 |
@@ -18,14 +18,14 @@ This document captures the specific version numbers as resolved by those policie
 | Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | Windows Server  | >= 2022                | 2024-01-22   | 2026-10-13 |
-| Windows Client  | >= 10                  | 2022-07-01   | 2025-11-01 |
+| Windows Client  | >= 11                  | 2025-12-16   | 2026-05-13 |
 
 ## macOS
 | Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
 |-------------------|------------------------|--------------|-------------|
 | Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
-| macOS (target)    | >= 11 (Big Sur)        | 2024-09-17   | 2025-07-30 |
-| iOS  (target)     | >= 15                  | 2024-01-24   | 2025-07-30 |
+| macOS (target)    | >= 12 (Monterey)       | 2025-12-16   | 2026-07-01 |
+| iOS  (target)     | >= 15                  | 2025-12-16   | 2026-09-15 |
 
 ## Android NDK
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
@@ -38,11 +38,11 @@ This document captures the specific version numbers as resolved by those policie
 |-----------------|------------------------|--------------|-------------|
 | C++ Version     | >= 17                  | 2024-12-17   | 2027-12-15  |
 | CMake           | >= 3.22                | 2025-06-04   | 2027-05-01 [^cmake] |
-| Bazel           | 8 LTS, 7 LTS           | 2025-05-12   | 2025-11-01  |
+| Bazel           | 8 LTS                  | 2025-12-16   | 2026-12-01  |
 | GCC             | >= 7.5.0               | 2024-07-01   | 2026-01-01 [^gcc] |
 | Clang           | >= 14.0.0              | 2025-06-04   | 2027-05-01 [^clang] |
 | MSVC            | >= 2022                | 2024-04-29   | 2027-01-12  |
-| Apple Clang     | >= 12                  | 2022-07-01   | 2025-07-30 |
+| Apple Clang     | >= 13                  | 2025-12-16   | 2026-07-01 |
 | glibc           | >= 2.27                | 2024-07-09   | TBD [^glibc] |
 | musl            | >= 1.2.4               | 2024-12-17   | 2025-05-09 |
 

--- a/foundational-dotnet-support-matrix.md
+++ b/foundational-dotnet-support-matrix.md
@@ -41,7 +41,7 @@ shown here. (Target frameworks are not automatically updated on minor releases.)
 
 | Dimension       | Supported Version | TFM    | Last Changed | Next Change |
 |-----------------|-------------------|--------|--------------|-------------|
-| .NET            | >= 6.0            | net6.0 | 2024-01-17   | 2025-11-12  |
+| .NET            | >= 8.0            | net8.0 | 2025-12-16   | 2026-11-10  |
 | .NET Framework  | >= 4.6.2          | net462 | 2024-01-17   | 2027-01-12  |
 
 ## .NET Standard

--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -5,7 +5,7 @@ The relevant policies are described at https://cloud.google.com/php/getting-star
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|
 | PHP Version | >= 8.1            | 2024-12-17   | 2025-12-31                 |
-| Composer    | >= 2.8            | 2024-10-07   | 2025-07-02                 |
+| Composer    | >= 2.9            | 2025-12-16   | 2026-04-01                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-python-support-matrix.md
+++ b/foundational-python-support-matrix.md
@@ -1,11 +1,11 @@
 
 # Foundational Python Support
 
-The relevant policies are described at https://opensource.google/documentation/policies/supported-python-versions. This document captures the specific version numbers as resolved by those policies.
+The relevant policies are described at https://docs.cloud.google.com/python/docs/supported-python-versions. This document captures the specific version numbers as resolved by those policies.
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
-| Python Version  | >= 3.9            | 2024-11-18   | 2025-10-31                 |
+| Python Version  | >= 3.10            | 2025-12-16   | 2026-10-31                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-ruby-support-matrix.md
+++ b/foundational-ruby-support-matrix.md
@@ -5,7 +5,7 @@ The relevant policies are described at https://cloud.google.com/ruby/getting-sta
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
-| Ruby Version    | >= 3.1            | 2025-06-02   | 2025-09-15                 |
+| Ruby Version    | >= 3.1            | 2025-06-02   | 2026-03-26                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the


### PR DESCRIPTION
taking over @shaod2's deltas (https://github.com/shaod2/oss-policies-info/commit/950b7194306638418ebb77f2f5aa4332b8901239)