### PR TITLE
Update PHP support to bump minimum to 8.2

### DIFF
--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -4,7 +4,7 @@ The relevant policies are described at https://cloud.google.com/php/getting-star
 
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|
-| PHP Version | >= 8.1            | 2024-12-17   | 2025-12-31                 |
+| PHP Version | >= 8.2            | 2024-12-17   | 2026-12-31                 |
 | Composer    | >= 2.9            | 2025-12-16   | 2026-04-01                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the


### PR DESCRIPTION
PHP 8.1 was meant to be dropped in December 2025 per https://www.php.net/supported-versions.php, but this table wasn't updated in time. Protobuf already dropped 8.1 as scheduled.