### PR TITLE
Update min gcc version to 10

### DIFF
--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -11,7 +11,7 @@ Note that some of these version supports apply broadly to other languages as wel
 | Alpine          | >= 3.21                | 2026-04-01   | 2026-11-01 |
 | Debian          | >= 11                  | 2024-07-01   | 2026-06-30 |
 | Fedora          | >= 42                  | 2025-12-16   | 2026-05-13 |
-| openSUSE        | >= Leap 15.6           | 2024-12-31   | 2026-04-30 |
+| openSUSE        | >= Leap 16.0           | 2026-05-01   | 2027-10-31 |
 | Ubuntu LTS      | >= 22.04               | 2025-06-04   | 2027-05-01 |
 | RHEL            | >= 9                   | 2024-07-01   | 2027-06-01 |
 | RockyLinux      | >= 9                   | 2024-07-01   | 2027-06-01 |
@@ -41,7 +41,7 @@ Note that some of these version supports apply broadly to other languages as wel
 | C++ Version     | >= 17                  | 2024-12-17   | 2027-12-15  |
 | CMake           | >= 3.22                | 2025-06-04   | 2027-05-01 [^cmake] |
 | Bazel           | 8 LTS                  | 2025-12-16   | 2026-12-01  |
-| GCC             | >= 7.5.0               | 2024-07-01   | 2026-04-30 [^gcc] |
+| GCC             | >= 10                  | 2026-05-01   | 2026-06-30 [^gcc] |
 | Clang           | >= 14.0.0              | 2025-06-04   | 2027-05-01 [^clang] |
 | MSVC            | >= 2022                | 2024-04-29   | 2027-01-12  |
 | Apple Clang     | >= 17                  | 2025-12-19   | 2026-07-01 |
@@ -57,8 +57,8 @@ supported distros. Currently that is CMake 3.22 as Ubuntu 22.04 ships with this
 version.
 
 [^gcc]: We support the oldest version of GCC that ships with one of the
-supported distros. Currently that is GCC 7.5.0 as openSUSE Leap 15.6 ships
-with this version.
+supported distros. Currently that is GCC 10 as Debian 11 ships with this
+version.
 
 [^clang]: We support the oldest version of Clang that ships with one of the
 supported distros. Currently that is Clang 14.0 as Ubuntu 22.04 ships with


### PR DESCRIPTION
openSUSE 15.6 reached EOL on 2026-04-30.

It usually takes them a while to update
https://en.opensuse.org/Lifetime.

https://news.opensuse.org/2026/04/01/leap-15-eol/
confirms this EOL date, though.

Debian 11 Bullseye uses gcc 10.

https://packages.debian.org/bullseye/gcc