### PR TITLE
Update Foundational Support Matrix.

### DIFF
--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -105,7 +105,7 @@ page shows Chrome's support timelines.
 | C++ Version     | >= 17                  | 2024-12-17   | 2027-12-15  |
 | CMake           | >= 3.22                | 2025-06-04   | 2027-05-01 [^cmake] |
 | Bazel           | 8 LTS                  | 2025-12-16   | 2026-12-01  |
-| GCC             | >= 10                  | 2026-07-09   | 2027-06-30 [^gcc] |
+| GCC             | >= 10                  | 2026-05-01   | 2027-06-30 [^gcc] |
 | Clang           | >= 14.0.0              | 2025-06-04   | 2027-05-01 [^clang] |
 | MSVC            | >= 2022                | 2024-04-29   | 2027-01-12  |
 | Apple Clang     | >= 21                  | 2026-07-09   | 2027-09-15 [^apple-clang] |
@@ -114,14 +114,19 @@ page shows Chrome's support timelines.
 
 ### Implied Support Matrix [Detailed Linux Breakdown]
 
-| Tool            | Debian   | Alpine   | Fedora/Red Hat | Rocky   | openSUSE | Ubuntu LTS | Last Changed | Next Change [^next-change] |
-|-----------------|---------------------|----------------|---------|----------|------------|--------------|-------------|
-| C++ Version     | >= 17    | >= 17    | >= 17          | >= 17   | >= 17    | >= 17      | 2024-12-17   | 2027-12-15  |
-| CMake           | >= 3.31  | >= 4.2.3 | >= 4.3.0       | >= 3.31 | >= 4.3.4 | >= 3.22    | 2026-07-09   | 2027-05-01 [^cmake] |
-| GCC             | >= 14.2  | >= 15.2  | >= 16.1        | >= 11.5 | >= 15.0  | >= 11.2    | 2026-07-09   | 2027-06-30 [^gcc] |
-| Clang           | >= 19.0  | >= 18.1  | >= 22.1        | >= 21.1 | >= 22.0  | >= 14.0    | 2026-07-09   | 2027-05-01 [^clang] |
-| glibc           | >= 2.41  | N/A      | >= 2.43        | >= 2.34 | >= 2.43  | >= 2.35    | 2026-07-09   | TBD [^glibc] |
-| musl            | >= 1.2.5 | >= 1.2.6 | >= 1.2.6       | N/A     | N/A      | >= 1.2.5   | 2026-07-09   | 2026-11-01 |
+This table charts the default package version from major Linux distributions
+that comes with a standard install on our oldest supported distro major version.
+
+NOTE: This table should be audited again on or after 2026-11-01.
+
+| Tool            | Debian   | Alpine   | Fedora   | Rocky   | openSUSE | Ubuntu LTS |
+|-----------------|---------------------|----------|---------|----------|------------|
+| C++ Version     | >= 17    | >= 17    | >= 17    | >= 17   | >= 17    | >= 17      |
+| CMake           | >= 3.31  | >= 4.2.3 | >= 4.3.0 | >= 3.31 | >= 4.3.4 | >= 3.22    |
+| GCC             | >= 14.2  | >= 15.2  | >= 16.1  | >= 11.5 | >= 15.0  | >= 11.2    |
+| Clang           | >= 19.0  | >= 18.1  | >= 22.1  | >= 21.1 | >= 22.0  | >= 14.0    |
+| glibc           | >= 2.41  | N/A      | >= 2.43  | >= 2.34 | >= 2.43  | >= 2.35    |
+| musl            | >= 1.2.5 | >= 1.2.6 | >= 1.2.6 | N/A     | N/A      | >= 1.2.5   |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -6,6 +6,18 @@ This document captures the specific version numbers as resolved by those policie
 Note that some of these version supports apply broadly to other languages as well, and are not exclusive to C++.
 
 ## Linux distributions
+
+### Cited Text
+
+> We will support releases of the following Linux distributions until the vendor
+> drops support.
+
+Vendor support is obtained from published support windows.
+https://endoflife.date/ consolidates these support windows on top of providing a
+visualization.
+
+### Implied Support Matrix
+
 | Distribution    | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | Alpine          | >= 3.21                | 2026-04-01   | 2026-11-01 |
@@ -17,24 +29,75 @@ Note that some of these version supports apply broadly to other languages as wel
 | RockyLinux      | >= 9                   | 2024-07-01   | 2027-06-01 |
 
 ## Windows
+
+### Cited Text
+
+> We will build using the **newest Windows** server platform available.
+>
+> We will support all the Windows versions that Microsoft supports.
+> i.  [Windows client support](https://docs.microsoft.com/en-us/windows/release-health/supported-versions-windows-client)
+> ii. [Windows server support](https://endoflife.date/windows-server)
+
+### Implied Support Matrix
+
 | Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | Windows Server  | >= 2022                | 2024-01-22   | 2026-10-13 |
 | Windows Client  | >= 11                  | 2025-12-16   | 2026-10-13 |
 
 ## macOS
+
+### Cited Text
+
+> We will build using the newest XCode available.
+> We will support back to the oldest macOS target platform needed by Chrome.
+> We will support back to the oldest iOS target platform that has a simulator.
+
+Note that Chrome has announced a update in minimum required OS version in
+[151](https://support.google.com/chrome/thread/404150391/sunsetting-support-for-macos-12-monterey-in-mid-2026?hl=en).
+In addition, the
+[Chrome browser system requirements](https://support.google.com/chrome/a/answer/7100626)
+page shows Chrome's support timelines.
+
+### Implied Support Matrix
 | Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
 |-------------------|------------------------|--------------|-------------|
 | Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
-| macOS (target)    | >= 14 (Monterey)       | 2026-06-06   | 2027-01-01 |
+| macOS (target)    | >= 13 (Ventura)        | 2026-06-06   | 2027-01-01 |
 | iOS  (target)     | >= 15                  | 2025-12-16   | 2026-09-15 |
 
 ## Android NDK
+
+### Cited Text
+
+> We will support Android -- we will build using the newest Android NDK and
+> target its lowest supported API level (example
+> [meta/platforms.json](https://android.googlesource.com/platform/ndk.git/+/refs/heads/master/meta/platforms.json)).
+
+### Implied Support Matrix
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
 |------------------------|------------------------|--------------|----------------------------|
-| Android API (target)   | >= 35                  | 2026-06-08   |                            |
+| Android API (target)   | >= 21                  | 2022-09-18   |                            |
 
 ## Compilers, tools, build systems
+
+### Cited Text
+
+> 1. We do not support any compiler that is EOL as defined by the vendor.
+> 1. We support GCC and Clang on our supported Linux distros (see above). We
+>    support the version installed by default (e.g., apt install gcc), unless
+>    we've explicitly excluded support for that version because it doesn't
+>    support other required policies of ours (e.g., we agree to remove GCC 4.8
+>    because of its incomplete C++11 support, as well as clang 3.x). If we
+>    cannot support the default version, we may instead support a newer version
+>    that's available from the vendor (e.g., devtoolset-7 on RHEL/CentOS 7)
+> 1. We support Apple Clang on our supported XCode version.
+> 1. We support MSVC on our supported Windows versions.
+>    1. We support the MSVC versions that are in the Mainstream Support window
+>       as defined by Microsoft's Fixed Lifecycle Policy.
+
+
+### Implied Support Matrix
 
 | Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -21,8 +21,8 @@ visualization.
 | Distribution    | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | Alpine          | >= 3.21                | 2026-04-01   | 2026-11-01 |
-| Debian          | >= 13                  | 2026-06-08   | 2027-06-30 |
-| Fedora          | >= 43                  | 2026-06-08   | 2026-12-10 |
+| Debian          | >= 13                  | 2026-07-09   | 2027-06-30 |
+| Fedora          | >= 43                  | 2026-07-09   | 2026-12-10 |
 | openSUSE        | >= Leap 16.0           | 2026-05-01   | 2027-10-31 |
 | Ubuntu LTS      | >= 22.04               | 2025-06-04   | 2027-05-01 |
 | RHEL            | >= 9                   | 2024-07-01   | 2027-06-01 |
@@ -53,7 +53,8 @@ visualization.
 > We will support back to the oldest macOS target platform needed by Chrome.
 > We will support back to the oldest iOS target platform that has a simulator.
 
-Note that Chrome has announced a update in minimum required OS version in
+Note that Chrome has announced an update in its minimum required macOS version
+in
 [151](https://support.google.com/chrome/thread/404150391/sunsetting-support-for-macos-12-monterey-in-mid-2026?hl=en).
 In addition, the
 [Chrome browser system requirements](https://support.google.com/chrome/a/answer/7100626)
@@ -63,7 +64,7 @@ page shows Chrome's support timelines.
 | Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
 |-------------------|------------------------|--------------|-------------|
 | Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
-| macOS (target)    | >= 13 (Ventura)        | 2026-06-06   | 2027-01-01 |
+| macOS (target)    | >= 13 (Ventura)        | 2026-07-09   | 2027-01-01 |
 | iOS  (target)     | >= 15                  | 2025-12-16   | 2026-09-15 |
 
 ## Android NDK
@@ -104,12 +105,23 @@ page shows Chrome's support timelines.
 | C++ Version     | >= 17                  | 2024-12-17   | 2027-12-15  |
 | CMake           | >= 3.22                | 2025-06-04   | 2027-05-01 [^cmake] |
 | Bazel           | 8 LTS                  | 2025-12-16   | 2026-12-01  |
-| GCC             | >= 10                  | 2026-05-01   | 2026-06-30 [^gcc] |
+| GCC             | >= 10                  | 2026-07-09   | 2027-06-30 [^gcc] |
 | Clang           | >= 14.0.0              | 2025-06-04   | 2027-05-01 [^clang] |
 | MSVC            | >= 2022                | 2024-04-29   | 2027-01-12  |
-| Apple Clang     | >= 17                  | 2025-12-19   | 2026-07-01 |
+| Apple Clang     | >= 21                  | 2026-07-09   | 2027-09-15 [^apple-clang] |
 | glibc           | >= 2.27                | 2024-07-09   | TBD [^glibc] |
 | musl            | >= 1.2.5               | 2026-04-01   | 2026-11-01 |
+
+### Implied Support Matrix [Detailed Linux Breakdown]
+
+| Tool            | Debian   | Alpine   | Fedora/Red Hat | Rocky   | openSUSE | Ubuntu LTS | Last Changed | Next Change [^next-change] |
+|-----------------|---------------------|----------------|---------|----------|------------|--------------|-------------|
+| C++ Version     | >= 17    | >= 17    | >= 17          | >= 17   | >= 17    | >= 17      | 2024-12-17   | 2027-12-15  |
+| CMake           | >= 3.31  | >= 4.2.3 | >= 4.3.0       | >= 3.31 | >= 4.3.4 | >= 3.22    | 2026-07-09   | 2027-05-01 [^cmake] |
+| GCC             | >= 14.2  | >= 15.2  | >= 16.1        | >= 11.5 | >= 15.0  | >= 11.2    | 2026-07-09   | 2027-06-30 [^gcc] |
+| Clang           | >= 19.0  | >= 18.1  | >= 22.1        | >= 21.1 | >= 22.0  | >= 14.0    | 2026-07-09   | 2027-05-01 [^clang] |
+| glibc           | >= 2.41  | N/A      | >= 2.43        | >= 2.34 | >= 2.43  | >= 2.35    | 2026-07-09   | TBD [^glibc] |
+| musl            | >= 1.2.5 | >= 1.2.6 | >= 1.2.6       | N/A     | N/A      | >= 1.2.5   | 2026-07-09   | 2026-11-01 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the
@@ -126,6 +138,9 @@ version.
 [^clang]: We support the oldest version of Clang that ships with one of the
 supported distros. Currently that is Clang 14.0 as Ubuntu 22.04 ships with
 this version.
+
+[^apple-clang]: A community-maintained version record can be found
+[here](https://gist.github.com/yamaya/2924292).
 
 [^glibc]: We plan to support glibc >= 2.27 until further notice.
 

--- a/foundational-cxx-support-matrix.md
+++ b/foundational-cxx-support-matrix.md
@@ -9,8 +9,8 @@ Note that some of these version supports apply broadly to other languages as wel
 | Distribution    | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | Alpine          | >= 3.21                | 2026-04-01   | 2026-11-01 |
-| Debian          | >= 11                  | 2024-07-01   | 2026-06-30 |
-| Fedora          | >= 42                  | 2025-12-16   | 2026-05-13 |
+| Debian          | >= 13                  | 2026-06-08   | 2027-06-30 |
+| Fedora          | >= 43                  | 2026-06-08   | 2026-12-10 |
 | openSUSE        | >= Leap 16.0           | 2026-05-01   | 2027-10-31 |
 | Ubuntu LTS      | >= 22.04               | 2025-06-04   | 2027-05-01 |
 | RHEL            | >= 9                   | 2024-07-01   | 2027-06-01 |
@@ -20,19 +20,19 @@ Note that some of these version supports apply broadly to other languages as wel
 | Dimension       | Supported Version      | Last Changed | Next Change [^next-change] |
 |-----------------|------------------------|--------------|-------------|
 | Windows Server  | >= 2022                | 2024-01-22   | 2026-10-13 |
-| Windows Client  | >= 11                  | 2025-12-16   | 2026-05-13 |
+| Windows Client  | >= 11                  | 2025-12-16   | 2026-10-13 |
 
 ## macOS
 | Dimension         | Supported Version      | Last Changed | Next Change [^next-change] |
 |-------------------|------------------------|--------------|-------------|
 | Xcode             | >= 26                  | 2025-09-15   | 2026-09-15 |
-| macOS (target)    | >= 12 (Monterey)       | 2025-12-16   | 2026-07-01 |
+| macOS (target)    | >= 14 (Monterey)       | 2026-06-06   | 2027-01-01 |
 | iOS  (target)     | >= 15                  | 2025-12-16   | 2026-09-15 |
 
 ## Android NDK
 | Dimension              | Supported Version      | Last Changed | Next Change [^next-change] |
 |------------------------|------------------------|--------------|----------------------------|
-| Android API (target)   | >= 21                  | 2022-09-18   |                            |
+| Android API (target)   | >= 35                  | 2026-06-08   |                            |
 
 ## Compilers, tools, build systems
 

--- a/foundational-java-support-matrix.md
+++ b/foundational-java-support-matrix.md
@@ -3,19 +3,25 @@
 
 The relevant policies are described at https://cloud.google.com/java/docs/supported-java-versions. This document captures the specific version numbers as resolved by those policies.
 
-| Dimension         | Supported Version | Last Changed | Next Change [^next-change] |
-|-------------------|-------------------|--------------|----------------------------|
-| Java Version      | >= 8              | 2024-01-30   | 2026-11-12                 |
-| Android API Level | >= 23             | 2026-06-08   | 2028-01-07                 |
+### Cited Text
 
-[^next-change]: This is an estimated date. The actual date may change if the
-vendor (or community, as applicable) extends or shortens the lifetime of the
-dimension in question.
-
-### Footnotes
+> Cloud Client Libraries for Java are compatible with, and tested against Java
+> 8, Java 11, Java 17, Java 21 and Java 25. Java 8 will continue to be supported
+> by Cloud Client Libraries for Java until at least September 2026.
 
 On Android, we support the minimum SDK version that is supported by
 [Android NDK](https://android.googlesource.com/platform/ndk/+/master/meta/platforms.json),
 [Google Play services](https://developers.google.com/android/guides/setup),
 and [Jetpack](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/docs/api_guidelines/modules.md#module-minsdkversion).
 If the versions differ, the lower version is supported.
+
+### Implied Support Matrix
+
+| Dimension         | Supported Version | Last Changed | Next Change [^next-change] |
+|-------------------|-------------------|--------------|----------------------------|
+| Java Version      | >= 8              | 2024-01-30   | 2026-11-12                 |
+| Android API Level | >= 21             | 2024-01-30   | 2027-01-07                 |
+
+[^next-change]: This is an estimated date. The actual date may change if the
+vendor (or community, as applicable) extends or shortens the lifetime of the
+dimension in question.

--- a/foundational-java-support-matrix.md
+++ b/foundational-java-support-matrix.md
@@ -6,7 +6,7 @@ The relevant policies are described at https://cloud.google.com/java/docs/suppor
 | Dimension         | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------------|-------------------|--------------|----------------------------|
 | Java Version      | >= 8              | 2024-01-30   | 2026-11-12                 |
-| Android API Level | >= 21             | 2024-01-30   | 2026-01-07                 |
+| Android API Level | >= 23             | 2026-06-08   | 2028-01-07                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -1,6 +1,21 @@
 # Foundational PHP Support
 
-The relevant policies are described at https://cloud.google.com/php/getting-started/supported-php-versions. This document captures the specific version numbers as resolved by those policies.
+The relevant policies are described at
+https://cloud.google.com/php/getting-started/supported-php-versions. This
+document captures the specific version numbers as resolved by those policies.
+
+### Cited Text
+
+> The Cloud Client Libraries for PHP are compatible with at least the three most
+> recent, major PHP releases. The libraries will always be compatible with at
+> least one GA runtime for App Engine and Cloud Run functions.
+
+PHP runtime documentation from Cloud Run: https://docs.cloud.google.com/run/docs/runtimes/php
+PHP runtime documentation from App Engine: https://docs.cloud.google.com/appengine/docs/flexible/php/runtime
+
+Generally speaking, Composer configuration should be automatic.
+
+### Implied Support Matrix
 
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|

--- a/foundational-php-support-matrix.md
+++ b/foundational-php-support-matrix.md
@@ -5,7 +5,7 @@ The relevant policies are described at https://cloud.google.com/php/getting-star
 | Dimension   | Supported Version | Last Changed | Next Change [^next-change] |
 |-------------|-------------------|--------------|----------------------------|
 | PHP Version | >= 8.2            | 2024-12-17   | 2026-12-31                 |
-| Composer    | >= 2.9            | 2025-12-16   | 2026-04-01                 |
+| Composer    | >= 2.10           | 2026-06-08   | 2026-12-31                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-python-support-matrix.md
+++ b/foundational-python-support-matrix.md
@@ -1,7 +1,18 @@
 
 # Foundational Python Support
 
-The relevant policies are described at https://docs.cloud.google.com/python/docs/supported-python-versions. This document captures the specific version numbers as resolved by those policies.
+The relevant policies are described at
+https://docs.cloud.google.com/python/docs/supported-python-versions. This
+document captures the specific version numbers as resolved by those policies.
+
+### Cited Text
+
+> Cloud Client Libraries for Python are compatible with all current active and
+> maintenance versions of Python. To see currently supported Python versions,
+> see [Supported Versions](https://devguide.python.org/versions/#supported-versions).
+
+
+### Implied Support Matrix
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|

--- a/foundational-python-support-matrix.md
+++ b/foundational-python-support-matrix.md
@@ -16,7 +16,7 @@ document captures the specific version numbers as resolved by those policies.
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
-| Python Version  | >= 3.10            | 2025-12-16   | 2026-10-31                 |
+| Python Version  | >= 3.10           | 2025-12-16   | 2026-10-31                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-ruby-support-matrix.md
+++ b/foundational-ruby-support-matrix.md
@@ -5,7 +5,7 @@ The relevant policies are described at https://cloud.google.com/ruby/getting-sta
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|
-| Ruby Version    | >= 3.1            | 2025-06-02   | 2026-03-26                 |
+| Ruby Version    | >= 3.2            | 2025-06-08   | 2027-03-26                 |
 
 [^next-change]: This is an estimated date. The actual date may change if the
 vendor (or community, as applicable) extends or shortens the lifetime of the

--- a/foundational-ruby-support-matrix.md
+++ b/foundational-ruby-support-matrix.md
@@ -1,7 +1,17 @@
 
 # Foundational Ruby Support
 
-The relevant policies are described at https://cloud.google.com/ruby/getting-started/supported-ruby-versions. This document captures the specific version numbers as resolved by those policies.
+The relevant policies are described at
+https://cloud.google.com/ruby/getting-started/supported-ruby-versions. This
+document captures the specific version numbers as resolved by those policies.
+
+### Cited Text
+
+> The Cloud Client Libraries for Ruby are compatible with all [actively supported
+> Ruby releases](https://www.ruby-lang.org/en/downloads/branches/), plus the
+> most recently end-of-life release for 12 months after the end-of-life date.
+
+### Implied Support Matrix
 
 | Dimension       | Supported Version | Last Changed | Next Change [^next-change] |
 |-----------------|-------------------|--------------|----------------------------|


### PR DESCRIPTION
Sources consulted:

Dotnet: clear.

Java: I think it's 23 and above:
- source for Google Play Services and Android JetPack https://apilevels.com/#:~:text=Android%206%20%2D%20Jetpack%2FAndroidX%20libraries%20require%20a,drops%20support%20for%20API%20levels%20below%2021.

PHP:
- Basing off the composer update off of this: https://github.com/composer/composer/releases?page=1
- Since Composer 2.10 is available, let's use that.

Ruby:
- Based on this support matrix: https://www.ruby-lang.org/en/downloads/branches/
- The currently active release plus the most recently EOL for 12 months. That leads to 3.2.

C++
Debian: https://endoflife.date/debian -- aggressively skipping bookworm. Fedora: https://endoflife.date/fedora
OpenSUSE: https://endoflife.date/opensuse
Windows: https://endoflife.date/windows
Windows client:
https://learn.microsoft.com/en-us/windows/release-health/supported-versions-windows-client macOS: https://endoflife.date/macos
iOS: https://developer.apple.com/support/xcode/ (XCode 27)
Android NDK API version: https://support.google.com/googleplay/android-developer/answer/11926878